### PR TITLE
Pin token list push actions

### DIFF
--- a/.github/workflows/build-pairs.yml
+++ b/.github/workflows/build-pairs.yml
@@ -42,7 +42,7 @@ jobs:
             git config --local user.name "github-actions[bot]"
             git commit -a -m "[bot] - Update lists"
         - name: Push changes
-          uses: ad-m/github-push-action@master
+          uses: ad-m/github-push-action@d30dc2d070765d7e509df00c34c5fa2dd636ff74
           with:
             github_token: ${{ secrets.ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
             branch: ${{ github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
             git config --local user.name "github-actions[bot]"
             git commit -a -m "[bot] - Update lists"
         - name: Push changes
-          uses: ad-m/github-push-action@master
+          uses: ad-m/github-push-action@d30dc2d070765d7e509df00c34c5fa2dd636ff74
           with:
             github_token: ${{ secrets.ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
             branch: ${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
             git config --local user.name "github-actions[bot]"
             git commit -a -m "[bot] - Update lists"
         - name: Push changes
-          uses: ad-m/github-push-action@master
+          uses: ad-m/github-push-action@d30dc2d070765d7e509df00c34c5fa2dd636ff74
           with:
             github_token: ${{ secrets.ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
             branch: ${{ github.ref }}


### PR DESCRIPTION
Pin token list publishing actions to immutable commits.

Notes:
- Replaces moving `ad-m/github-push-action@master` refs in workflows that use token/RPC secrets and push credentials.
- Reduces supply-chain exposure from upstream branch movement.
- Validated touched workflows with PyYAML and git diff --check.